### PR TITLE
Fix team link on FAQ page

### DIFF
--- a/_site/faq.html
+++ b/_site/faq.html
@@ -139,7 +139,7 @@
 
         </p>
         <h3>Who is the team behind the site?</h3>
-        <p id="faq-q">We're a group of friends united around creating a more inclusive society and supporting marginalized voices. You can learn more about us by visiting the <a href="/#team">team</a> page.</p>
+        <p id="faq-q">We're a group of friends united around creating a more inclusive society and supporting marginalized voices. You can learn more about us by visiting the <a href="/team">team</a> page.</p>
      
     </div>
 </div>


### PR DESCRIPTION
The link to the team in the FAQ currently redirects to the homepage - this sends it to the team page instead.